### PR TITLE
Minor fixes to GTest/Conan example

### DIFF
--- a/gtest-conan/index.md
+++ b/gtest-conan/index.md
@@ -17,10 +17,10 @@
 :::
 
 ```sh
-conan install . -s build_type=Debug
+conan install . -s build_type=Debug --build=missing
 cmake --preset conan-debug
 cmake --build --preset conan-debug
-./build/hi
+./build/Debug/hi
 ctest --preset conan-debug
 ```
 


### PR DESCRIPTION
- Add `--build=missing` to the `conan install` command
- Correct the path to hi executable to include the build type dir