### PR TITLE
Add link to GTest/Conan example

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,6 +42,7 @@ software build process.
 
 ### 🧪 Testing & analysis
 
+- [Test with GTest via Conan](/gtest-conan/)
 - [Test with GTest via CPM](/gtest-cpm/)
 - [Test with CTest via CPM](/unity-cpm/)
 - [Test with Boost.Test via CPM](/boost-test-cpm/)


### PR DESCRIPTION
I couldn't find a link to the GTest via Conan example so adding that under the "Testing & analysis" section. 